### PR TITLE
Apply spotless

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Verify
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
     name: Verify
     uses: takari/takari-gh-actions/.github/workflows/ci.yml@v2
     with:
-      jdk-matrix: '[ 8 ]' # for POM one JDK is enough
+      jdk-matrix: '[ 11 ]' # for POM one JDK is enough

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ on:
 jobs:
   build:
     name: Verify
-    uses: takari/takari-gh-actions/.github/workflows/ci.yml@v2
+    uses: takari/takari-gh-actions/.github/workflows/ci.yml@v3
     with:
       jdk-matrix: '[ 11 ]' # for POM one JDK is enough

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 target/
-.project
 .classpath
-.settings/
-bin
+.project
+.settings
+*.iml
+.idea
+out/
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -321,13 +321,6 @@
               <enabled>true</enabled>
             </upToDateChecking>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-shared-resources</artifactId>
-              <version>5</version>
-            </dependency>
-          </dependencies>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,9 @@
             </goals>
             <configuration>
               <rules>
+                <requireJavaVersion>
+                  <version>[11,)</version>
+                </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.6.3,)</version>
                 </requireMavenVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014 Takari, Inc.
+    Copyright (c) 2016 Takari, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -264,33 +264,38 @@
           <configuration>
             <aggregate>true</aggregate>
             <strictCheck>true</strictCheck>
-            <header>${takari.licenseHeader}</header>
             <useDefaultExcludes>false</useDefaultExcludes>
-            <includes>
-              <include>**/pom.xml</include>
-              <include>**/*.xml</include>
-              <include>**/*.xsd</include>
-              <include>**/*.xjb</include>
-              <include>**/*.mdo</include>
-              <include>**/*.properties</include>
-              <include>**/*.java</include>
-              <include>**/*.groovy</include>
-              <include>**/*.scala</include>
-              <include>**/*.aj</include>
-              <include>**/*.js</include>
-              <include>**/*.css</include>
-            </includes>
-            <excludes>
-              <exclude>**/target/**</exclude>
-              <exclude>**/conf/**</exclude>
-              <exclude>**/.*</exclude>
-              <exclude>**/pkg/**</exclude>
-              <exclude>**/.idea/**</exclude>
-              <exclude>**/release.properties</exclude>
-              <exclude>**/pom.xml.releaseBackup</exclude>
-              <exclude>release.sh</exclude>
-              <exclude>**/src/test/**</exclude>
-            </excludes>
+            <licenseSets>
+              <licenseSet>
+                <header>${takari.licenseHeader}</header>
+                <includes>
+                  <include>**/pom.xml</include>
+                  <include>**/*.xml</include>
+                  <include>**/*.xsd</include>
+                  <include>**/*.xjb</include>
+                  <include>**/*.mdo</include>
+                  <include>**/*.properties</include>
+                  <include>**/*.java</include>
+                  <include>**/*.groovy</include>
+                  <include>**/*.scala</include>
+                  <include>**/*.aj</include>
+                  <include>**/*.js</include>
+                  <include>**/*.css</include>
+                </includes>
+                <excludes>
+                  <exclude>.mvn/wrapper/**</exclude>
+                  <exclude>**/target/**</exclude>
+                  <exclude>**/conf/**</exclude>
+                  <exclude>**/.*</exclude>
+                  <exclude>**/pkg/**</exclude>
+                  <exclude>**/.idea/**</exclude>
+                  <exclude>**/release.properties</exclude>
+                  <exclude>**/pom.xml.releaseBackup</exclude>
+                  <exclude>release.sh</exclude>
+                  <exclude>**/src/test/**</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <scala>JAVADOC_STYLE</scala>
               <xjb>XML_STYLE</xjb>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   <version>53-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Takari</name>
-  <url>http://takari.io</url>
   <description>Takari: The future of software delivery.</description>
+  <url>http://takari.io</url>
 
   <licenses>
     <license>
@@ -55,6 +55,13 @@
       <timezone>-8</timezone>
     </developer>
   </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:takari/takari-pom.git</connection>
+    <developerConnection>scm:git:git@github.com:takari/takari-pom.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>http://github.com/takari/takari-pom</url>
+  </scm>
 
   <distributionManagement>
     <repository>
@@ -103,40 +110,7 @@
     <maven.compiler.target>${takari.javaSourceVersion}</maven.compiler.target>
   </properties>
 
-  <scm>
-    <connection>scm:git:git@github.com:takari/takari-pom.git</connection>
-    <developerConnection>scm:git:git@github.com:takari/takari-pom.git</developerConnection>
-    <url>http://github.com/takari/takari-pom</url>
-    <tag>HEAD</tag>
-  </scm>
-
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.6.3,)</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>io.takari.maven.plugins</groupId>
-        <artifactId>takari-lifecycle-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
     <pluginManagement>
       <plugins>
         <!-- set versions/configuration of common plugins for reproducibility, ordered alphabetically -->
@@ -324,6 +298,45 @@
             </mapping>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.43.0</version>
+          <configuration>
+            <java>
+              <!-- orders of used formatters are important MPOM-376 -->
+              <!-- eg. palantir override importOrder, so should be first -->
+              <palantirJavaFormat />
+              <removeUnusedImports />
+              <importOrder />
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+                <!-- https://issues.apache.org/jira/browse/MRELEASE-1111 -->
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-shared-resources</artifactId>
+              <version>5</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${spotless.action}</goal>
+              </goals>
+              <phase>process-sources</phase>
+            </execution>
+          </executions>
+        </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
@@ -351,9 +364,61 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.6.3,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.takari.maven.plugins</groupId>
+        <artifactId>takari-lifecycle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <id>format-check</id>
+      <activation>
+        <property>
+          <name>!format</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>check</spotless.action>
+      </properties>
+    </profile>
+    <profile>
+      <id>format</id>
+      <activation>
+        <property>
+          <name>format</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>apply</spotless.action>
+      </properties>
+    </profile>
     <!-- START SNIPPET: release-profile -->
     <profile>
       <id>takari-release</id>


### PR DESCRIPTION
Pretty much same scheme as in Maven project:
* check runs in build and will fail it if not properly formatted
* mvn spotless:apply to format (or -P format)

Fixes https://github.com/takari/takari-pom/issues/13

Due spotless plugin (does not run on Java8) the "build time Java requirement" raises to Java 11, but IMHO this is not a problem as we already build most of the projects with it.

---

Applying this parent in project will need 3 steps:
* PR to change parent version (build will fail due formatting)
* subsequent commit where developer runs `mvn spotless:apply` and pushes (build will pass)
* subsequent commit to repository root into file `.git-blame-ignore-revs` with commit hash from 2nd commit